### PR TITLE
fix: fix car, announcement and image entity properties

### DIFF
--- a/src/entities/announcements.entity.ts
+++ b/src/entities/announcements.entity.ts
@@ -3,7 +3,6 @@ import {Car} from "./cars.entity"
 import { CarImage } from "./carsImages.entity";
 
 @Entity("announcements")
-
 export class Announcement {
     @PrimaryGeneratedColumn("uuid")
     id: string
@@ -30,9 +29,9 @@ export class Announcement {
     description: string
 
     @ManyToOne(() => Car)
-    carId: Car;
+    car: Car;
 
     @OneToOne(() => CarImage, carImage => carImage.announcement)
     @JoinColumn()
-    imageId: CarImage;
+    image: CarImage;
 }

--- a/src/entities/cars.entity.ts
+++ b/src/entities/cars.entity.ts
@@ -12,6 +12,6 @@ import { Announcement } from "./announcements.entity";
     @Column({type:"varchar", length:20})
     model: string
 
-    @OneToMany(() => Announcement, (announcements) => announcements.carId, { nullable: true })
+    @OneToMany(() => Announcement, (announcements) => announcements.car, { nullable: true })
     annoucements: Announcement[];
 }

--- a/src/entities/carsImages.entity.ts
+++ b/src/entities/carsImages.entity.ts
@@ -15,6 +15,6 @@ import { Announcement } from "./announcements.entity";
     @Column({type:"varchar", length:255})
     second_image: string
 
-    @OneToOne(() => Announcement, ann => ann.imageId)
+    @OneToOne(() => Announcement, ann => ann.image)
     announcement: Announcement;
 }

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -1,0 +1,5 @@
+import { Car } from "./cars.entity"
+import { Announcement } from "./announcements.entity"
+import { CarImage } from "./carsImages.entity"
+
+export { Car, Announcement, CarImage }


### PR DESCRIPTION
Foi feita uma alteração nas propriedades que representam a FK das entidades, onde antes tinha sido adicionado "Id", o nome da propriedade acabou ficando com o "Id" duplicado no banco de dados.